### PR TITLE
feat: migrate to Istio HTTPRoute and add allowed_groups RBAC

### DIFF
--- a/charts/thanos/templates/httproutes.yaml
+++ b/charts/thanos/templates/httproutes.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.httproutes.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: thanos-bucketweb
+spec:
+  parentRefs:
+    - name: {{ .Values.httproutes.gateway_name | default "istio-gateway" }}
+      namespace: {{ .Values.httproutes.gateway_namespace | default "istio-ingress" }}
+      sectionName: https
+  hostnames:
+    - {{ .Values.httproutes.bucketweb_host | quote }}
+  rules:
+    - backendRefs:
+        - name: thanos-bucketweb
+          port: 9075
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: thanos-query-frontend
+spec:
+  parentRefs:
+    - name: {{ .Values.httproutes.gateway_name | default "istio-gateway" }}
+      namespace: {{ .Values.httproutes.gateway_namespace | default "istio-ingress" }}
+      sectionName: https
+  hostnames:
+    - {{ .Values.httproutes.query_host | quote }}
+  rules:
+    - backendRefs:
+        - name: thanos-query-frontend
+          port: 9075
+{{- end }}

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -18,5 +18,7 @@ module "thanos" {
 
   thanos = var.thanos
 
+  allowed_groups = var.allowed_groups
+
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/locals.tf
+++ b/locals.tf
@@ -131,7 +131,7 @@ locals {
             "--cookie-secret=${replace(random_password.oauth2_cookie_secret.result, "\"", "\\\"")}",
             "--email-domain=*",
             "--redirect-url=https://${local.thanos.bucketweb_domain}/oauth2/callback",
-          ], local.thanos.oidc.oauth2_proxy_extra_args)
+          ], local.thanos.oidc.oauth2_proxy_extra_args, [for g in var.allowed_groups : "--allowed-group=${g}"])
           image = local.oauth2_proxy_image
           name  = "thanos-proxy"
           ports = [{
@@ -215,7 +215,7 @@ locals {
             "--cookie-secret=${replace(random_password.oauth2_cookie_secret.result, "\"", "\\\"")}",
             "--email-domain=*",
             "--redirect-url=https://${local.thanos.query_domain}/oauth2/callback",
-          ], local.thanos.oidc.oauth2_proxy_extra_args)
+          ], local.thanos.oidc.oauth2_proxy_extra_args, [for g in var.allowed_groups : "--allowed-group=${g}"])
           image = local.oauth2_proxy_image
           name  = "thanos-proxy"
           ports = [{

--- a/locals.tf
+++ b/locals.tf
@@ -1,12 +1,6 @@
 locals {
   oauth2_proxy_image = "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
 
-  ingress_annotations = {
-    "cert-manager.io/cluster-issuer"                   = "${var.cluster_issuer}"
-    "traefik.ingress.kubernetes.io/router.entrypoints" = "websecure"
-    "traefik.ingress.kubernetes.io/router.tls"         = "true"
-  }
-
   # values.yaml translated into HCL structures.
   # Possible values available here -> https://github.com/bitnami/charts/tree/master/bitnami/thanos/
   helm_values = [{
@@ -129,11 +123,11 @@ locals {
           args = concat([
             "--http-address=0.0.0.0:9075",
             "--upstream=http://localhost:8080",
-            "--provider=oidc",
+            "--provider=keycloak-oidc",
             "--oidc-issuer-url=${replace(local.thanos.oidc.issuer_url, "\"", "\\\"")}",
             "--client-id=${replace(local.thanos.oidc.client_id, "\"", "\\\"")}",
             "--client-secret=${replace(local.thanos.oidc.client_secret, "\"", "\\\"")}",
-            "--cookie-secure=false",
+            "--cookie-secure=true",
             "--cookie-secret=${replace(random_password.oauth2_cookie_secret.result, "\"", "\\\"")}",
             "--email-domain=*",
             "--redirect-url=https://${local.thanos.bucketweb_domain}/oauth2/callback",
@@ -154,37 +148,7 @@ locals {
           }]
         }
         ingress = {
-          enabled     = true
-          annotations = local.ingress_annotations
-          tls         = false
-          hostname    = ""
-          extraRules = [
-            {
-              host = "${local.thanos.bucketweb_domain}"
-              http = {
-                paths = [
-                  {
-                    backend = {
-                      service = {
-                        name = "thanos-bucketweb"
-                        port = {
-                          name = "proxy"
-                        }
-                      }
-                    }
-                    path     = "/"
-                    pathType = "ImplementationSpecific"
-                  }
-                ]
-              }
-            },
-          ]
-          extraTls = [{
-            secretName = "thanos-bucketweb-tls"
-            hosts = [
-              "${local.thanos.bucketweb_domain}"
-            ]
-          }]
+          enabled = false
         }
         networkPolicy = {
           enabled = false
@@ -243,11 +207,11 @@ locals {
           args = concat([
             "--http-address=0.0.0.0:9075",
             "--upstream=http://localhost:9090",
-            "--provider=oidc",
+            "--provider=keycloak-oidc",
             "--oidc-issuer-url=${replace(local.thanos.oidc.issuer_url, "\"", "\\\"")}",
             "--client-id=${replace(local.thanos.oidc.client_id, "\"", "\\\"")}",
             "--client-secret=${replace(local.thanos.oidc.client_secret, "\"", "\\\"")}",
-            "--cookie-secure=false",
+            "--cookie-secure=true",
             "--cookie-secret=${replace(random_password.oauth2_cookie_secret.result, "\"", "\\\"")}",
             "--email-domain=*",
             "--redirect-url=https://${local.thanos.query_domain}/oauth2/callback",
@@ -268,37 +232,7 @@ locals {
           }]
         }
         ingress = {
-          enabled     = true
-          annotations = local.ingress_annotations
-          tls         = false
-          hostname    = ""
-          extraRules = [
-            {
-              host = "${local.thanos.query_domain}"
-              http = {
-                paths = [
-                  {
-                    backend = {
-                      service = {
-                        name = "thanos-query-frontend"
-                        port = {
-                          name = "proxy"
-                        }
-                      }
-                    }
-                    path     = "/"
-                    pathType = "ImplementationSpecific"
-                  }
-                ]
-              }
-            },
-          ]
-          extraTls = [{
-            secretName = "thanos-query-tls"
-            hosts = [
-              "${local.thanos.query_domain}"
-            ]
-          }]
+          enabled = false
         }
         networkPolicy = {
           enabled = false
@@ -357,4 +291,14 @@ locals {
     local.thanos_defaults,
     var.thanos,
   )
+
+  helm_values_httproutes = [{
+    httproutes = {
+      enabled           = true
+      gateway_name      = var.gateway_name
+      gateway_namespace = var.gateway_namespace
+      bucketweb_host    = local.thanos.bucketweb_domain
+      query_host        = local.thanos.query_domain
+    }
+  }]
 }

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "random_password" "oauth2_cookie_secret" {
 }
 
 data "utils_deep_merge_yaml" "values" {
-  input       = [for i in concat(local.helm_values, var.helm_values) : yamlencode(i)]
+  input       = [for i in concat(local.helm_values, local.helm_values_httproutes, var.helm_values) : yamlencode(i)]
   append_list = var.deep_merge_append_list
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -174,3 +174,15 @@ variable "enable_service_monitor" {
   type        = bool
   default     = false
 }
+
+variable "gateway_name" {
+  description = "Name of the Istio Gateway resource to attach HTTPRoutes to."
+  type        = string
+  default     = "istio-gateway"
+}
+
+variable "gateway_namespace" {
+  description = "Namespace where the Istio Gateway resource is deployed."
+  type        = string
+  default     = "istio-ingress"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -186,3 +186,9 @@ variable "gateway_namespace" {
   type        = string
   default     = "istio-ingress"
 }
+
+variable "allowed_groups" {
+  description = "List of Keycloak groups allowed to access Thanos. When empty, any authenticated user is allowed."
+  type        = list(string)
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -188,7 +188,7 @@ variable "gateway_namespace" {
 }
 
 variable "allowed_groups" {
-  description = "List of Keycloak groups allowed to access Thanos. When empty, any authenticated user is allowed."
+  description = "List of Keycloak groups allowed to access Thanos (e.g. [\"modern-gitops-stack-admins\"]). When empty, any authenticated user is allowed."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
## Changes

- Migrate ingress from Traefik to Istio Gateway API HTTPRoute
- Add `allowed_groups` variable for RBAC via oauth2-proxy sidecars
- Improve `allowed_groups` variable description